### PR TITLE
Constantize a few values used for the tests.

### DIFF
--- a/src/gossie/connection_test.go
+++ b/src/gossie/connection_test.go
@@ -10,23 +10,23 @@ import (
 func TestConnection(t *testing.T) {
 
 	/* kind of pointless
-	   c, err := newConnection("127.0.0.1:9999", "NotExists", 3000)
+	   c, err := newConnection(invalidEndpoint, "NotExists", standardTimeout)
 	   if err == nil {
 	       t.Fatal("Invalid connection parameters did not return error")
 	   }
 	*/
 
-	c, err := newConnection("127.0.0.1:9160", "NotExists", 1000)
+	c, err := newConnection(localEndpoint, "NotExists", shortTimeout)
 	if err == nil {
 		t.Fatal("Invalid keyspace did not return error")
 	}
 
-	c, err = newConnection("127.0.0.1:9160", "TestGossie", 1000)
+	c, err = newConnection(localEndpoint, keyspace, shortTimeout)
 	if err != nil {
 		t.Fatal("Error connecting to Cassandra:", err)
 	}
 
-	if c.keyspace != "TestGossie" {
+	if c.keyspace != keyspace {
 		t.Fatal("Invalid keyspace")
 	}
 
@@ -36,30 +36,30 @@ func TestConnection(t *testing.T) {
 func TestNewConnectionPool(t *testing.T) {
 
 	/* kind of pointless
-	   cp, err := NewConnectionPool([]string{"127.0.0.1:9999"}, "NotExists", PoolOptions{Size: 50, Timeout: 3000})
+	   cp, err := NewConnectionPool([]string{invalidEndpoint}, "NotExists", poolOptions)
 	   if err == nil {
 	       t.Fatal("Invalid connection parameters did not return error")
 	   }
 	*/
 
-	cp, err := NewConnectionPool([]string{"127.0.0.1:9160"}, "NotExists", PoolOptions{Size: 50, Timeout: 3000})
+	cp, err := NewConnectionPool(localEndpointPool, "NotExists", poolOptions)
 	if err == nil {
 		t.Fatal("Invalid keyspace did not return error")
 	}
 
 	/* kind of pointless
-	   cp, err = NewConnectionPool([]string{"127.0.0.1:9160", "127.0.0.1:9170", "127.0.0.1:9180"}, "TestGossie", PoolOptions{Size: 50, Timeout: 3000})
+	   cp, err = NewConnectionPool(localEndpointsPool, keyspace, poolOptions)
 	   if err != nil {
 	       t.Fatal("Error connecting to Cassandra:", err)
 	   }
 	*/
 
-	cp, err = NewConnectionPool([]string{"127.0.0.1:9160"}, "TestGossie", PoolOptions{Size: 50, Timeout: 3000})
+	cp, err = NewConnectionPool(localEndpointPool, keyspace, poolOptions)
 	if err != nil {
 		t.Fatal("Error connecting to Cassandra:", err)
 	}
 
-	if cp.Keyspace() != "TestGossie" {
+	if cp.Keyspace() != keyspace {
 		t.Fatal("Invalid keyspace")
 	}
 
@@ -70,7 +70,7 @@ func TestAcquireRelease(t *testing.T) {
 	var err error
 	var c *connection
 
-	cpI, err := NewConnectionPool([]string{"127.0.0.1:9160"}, "TestGossie", PoolOptions{Size: 1, Grace: 1})
+	cpI, err := NewConnectionPool(localEndpointPool, keyspace, PoolOptions{Size: 1, Grace: 1})
 	if err != nil {
 		t.Fatal("Error connecting to Cassandra:", err)
 	}
@@ -96,7 +96,7 @@ func TestAcquireRelease(t *testing.T) {
 	c, err = cp.acquire()
 	check(0, false)
 
-	cp.blacklist("127.0.0.1:9160")
+	cp.blacklist(localEndpoint)
 	check(1, false)
 
 	c, err = cp.acquire()
@@ -111,7 +111,7 @@ func TestAcquireRelease(t *testing.T) {
 func TestRun(t *testing.T) {
 	var err error
 
-	cpI, err := NewConnectionPool([]string{"127.0.0.1:9160"}, "TestGossie", PoolOptions{Size: 1})
+	cpI, err := NewConnectionPool(localEndpointPool, keyspace, PoolOptions{Size: 1})
 	if err != nil {
 		t.Fatal("Error connecting to Cassandra:", err)
 	}

--- a/src/gossie/const_test.go
+++ b/src/gossie/const_test.go
@@ -1,0 +1,15 @@
+package gossie
+
+var (
+	invalidEndpoint    = "localhost:9999"
+	localEndpoint      = "localhost:9160"
+	localEndpointPool  = []string{localEndpoint}
+	localEndpointsPool = []string{localEndpoint, "localhost:9170", "localhost:9180"}
+
+	keyspace = "TestGossie"
+
+	standardTimeout = 3000
+	shortTimeout    = 1000
+
+	poolOptions = PoolOptions{Size: 50, Timeout: standardTimeout}
+)

--- a/src/gossie/query_test.go
+++ b/src/gossie/query_test.go
@@ -155,7 +155,7 @@ func createCompositeFull(t *testing.T, cp ConnectionPool) int {
 }
 
 func TestQueryGet(t *testing.T) {
-	cp, err := NewConnectionPool([]string{"127.0.0.1:9160"}, "TestGossie", PoolOptions{Size: 1, Timeout: 1000})
+	cp, err := NewConnectionPool(localEndpointPool, keyspace, PoolOptions{Size: 1, Timeout: shortTimeout})
 	if err != nil {
 		t.Fatal("Error connecting to Cassandra:", err)
 	}

--- a/src/gossie/readerwriter_test.go
+++ b/src/gossie/readerwriter_test.go
@@ -122,7 +122,7 @@ func buildIntSliceFromRow(row *Row) []int64 {
 }
 
 func TestWriterAndReader(t *testing.T) {
-	cp, err := NewConnectionPool([]string{"127.0.0.1:9160"}, "TestGossie", PoolOptions{Size: 1, Timeout: 1000})
+	cp, err := NewConnectionPool(localEndpointPool, keyspace, PoolOptions{Size: 1, Timeout: shortTimeout})
 	if err != nil {
 		t.Fatal("Error connecting to Cassandra:", err)
 	}
@@ -352,7 +352,7 @@ func TestWriterAndReader(t *testing.T) {
 /*
 func BenchmarkGet(b *testing.B) {
     b.StopTimer()
-    cp, _ := NewConnectionPool([]string{"127.0.0.1:9160"}, "TestGossie", PoolOptions{Size: 1, Timeout: 1000})
+    cp, _ := NewConnectionPool(localEndpointPool, keyspace, PoolOptions{Size: 1, Timeout: shortTimeout})
     b.StartTimer()
     for i := 0; i < b.N; i++ {
         cp.Reader().Cf("AllTypes").Get([]byte("a"))
@@ -361,7 +361,7 @@ func BenchmarkGet(b *testing.B) {
 
 func BenchmarkInsert(b *testing.B) {
     b.StopTimer()
-    cp, _ := NewConnectionPool([]string{"127.0.0.1:9160"}, "TestGossie", PoolOptions{Size: 1, Timeout: 1000})
+    cp, _ := NewConnectionPool(localEndpointPool, keyspace, PoolOptions{Size: 1, Timeout: shortTimeout})
     row := buildAllTypesRow("row")
     b.StartTimer()
     for i := 0; i < b.N; i++ {

--- a/src/gossie/schema_test.go
+++ b/src/gossie/schema_test.go
@@ -6,12 +6,12 @@ import (
 
 func TestSchema(t *testing.T) {
 
-	c, err := newConnection("127.0.0.1:9160", "TestGossie", 3000)
+	c, err := newConnection(localEndpoint, keyspace, standardTimeout)
 	if err != nil {
 		t.Fatal("Error connecting to Cassandra:", err)
 	}
 
-	ksDef, _, _, _ := c.client.DescribeKeyspace("TestGossie")
+	ksDef, _, _, _ := c.client.DescribeKeyspace(keyspace)
 
 	schema := newSchema(ksDef)
 	defer c.close()


### PR DESCRIPTION
In preparation for making more substantive changes to Gossie's tests,
I would like to do a little bit of clean-up work.  This commit merely
turns a few values into constants.  My next commit automatically
creates the test keyspace with associated column families, etc.
