### PR TITLE
Add support for the Valueless Columns pattern

### DIFF
--- a/src/gossie/mapping.go
+++ b/src/gossie/mapping.go
@@ -106,9 +106,6 @@ func NewMapping(source interface{}) (Mapping, error) {
 	case "sparse":
 		return newSparseMapping(si, cf, key, colsS...), nil
 	case "compact":
-		if value == "" {
-			return nil, errors.New(fmt.Sprint("Mandatory struct tag value for compact mapping not found in passed struct of type ", si.rtype.Name()))
-		}
 		return newCompactMapping(si, cf, key, value, colsS...), nil
 	}
 
@@ -389,7 +386,7 @@ func (m *compactMapping) Map(source interface{}) (*Row, error) {
 		}
 		row.Columns = append(row.Columns, &Column{Name: composite, Value: columnValue})
 	} else {
-		return nil, errors.New(fmt.Sprint("Mapping value field ", m.value, " not found in passed struct of type ", v.Type().Name()))
+		row.Columns = append(row.Columns, &Column{Name: composite, Value: []byte{}})
 	}
 	return row, nil
 }
@@ -423,8 +420,6 @@ func (m *compactMapping) Unmap(destination interface{}, provider RowProvider) er
 		if err != nil {
 			return errors.New(fmt.Sprint("Error unmarshaling column for compact value: ", err))
 		}
-	} else {
-		return errors.New(fmt.Sprint("Mapping value field ", m.value, " not found in passed struct of type ", v.Type().Name()))
 	}
 
 	return nil

--- a/src/gossie/mapping_test.go
+++ b/src/gossie/mapping_test.go
@@ -48,6 +48,12 @@ type tagsC struct {
 	D int
 }
 
+type tagsD struct {
+	A int `cf:"1" key:"A" cols:"B,C" mapping:"compact"`
+	B int
+	C int
+}
+
 type structTestShell struct {
 	mapping        Mapping
 	expectedStruct interface{}
@@ -118,6 +124,7 @@ func TestMap(t *testing.T) {
 	mA, _ := NewMapping(&tagsA{})
 	mB, _ := NewMapping(&tagsB{})
 	mC, _ := NewMapping(&tagsC{})
+	mD, _ := NewMapping(&tagsD{})
 	mE, _ := NewMapping(&everythingComp{})
 
 	shells := []*structTestShell{
@@ -172,6 +179,22 @@ func TestMap(t *testing.T) {
 					&Column{
 						Name:  []byte{0, 8, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 3, 0},
 						Value: []byte{0, 0, 0, 0, 0, 0, 0, 4},
+					},
+				},
+			},
+		},
+
+		&structTestShell{
+			mapping:        mD,
+			name:           "tagsD",
+			expectedStruct: &tagsD{1, 2, 3},
+			resultStruct:   &tagsD{},
+			expectedRow: &Row{
+				Key: []byte{0, 0, 0, 0, 0, 0, 0, 1},
+				Columns: []*Column{
+					&Column{
+						Name:  []byte{0, 8, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 3, 0},
+						Value: []byte{},
 					},
 				},
 			},


### PR DESCRIPTION
There are times when the column names serve as values themselves.
This changeset enables this pattern in compact mapping.
