### PR TITLE
Zero time marshal/unmarshal

### DIFF
--- a/src/gossie/types.go
+++ b/src/gossie/types.go
@@ -229,7 +229,12 @@ func marshalInt(value int64, size int, typeDesc TypeDesc) ([]byte, error) {
 }
 
 func marshalTime(value time.Time, typeDesc TypeDesc) ([]byte, error) {
+	if value.IsZero() {
+		return []byte{}, nil
+	}
+
 	switch typeDesc {
+
 	// following Java conventions Cassandra standarizes this as millis
 	case LongType, BytesType, DateType:
 		valueI := value.UnixNano() / 1e6
@@ -421,6 +426,12 @@ func unmarshalInt64(b []byte, typeDesc TypeDesc, value *int64) error {
 }
 
 func unmarshalTime(b []byte, typeDesc TypeDesc, value *time.Time) error {
+
+	if len(b) == 0 {
+		*value = *new(time.Time)
+		return nil
+	}
+
 	switch typeDesc {
 	case LongType, BytesType, DateType:
 		if len(b) != 8 {

--- a/src/gossie/types_test.go
+++ b/src/gossie/types_test.go
@@ -374,3 +374,22 @@ func TestMarshalTime(t *testing.T) {
 	errorMarshal(t, v, BooleanType)
 	errorMarshal(t, v, DoubleType)
 }
+
+func TestMarshalUnmarshalZeroTime(t *testing.T) {
+	zeroT := *new(time.Time)
+	b, err := marshalTime(zeroT, LongType)
+	if err != nil {
+		t.Fatalf("Failed to marshal time: %v", err)
+	}
+	// now get back to where we were
+	unmarshaledT := new(time.Time)
+	err = unmarshalTime(b, LongType, unmarshaledT)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal time: %v", err)
+	}
+
+	// must still be zero time
+	if !unmarshaledT.IsZero() {
+		t.Fatalf("Unmarshaled time is not zero time: %#v", unmarshaledT)
+	}
+}


### PR DESCRIPTION
This adds support for marshal/unmarshal zero time. I'm storing it as `[]byte{}` which makes some sense, but I'm not entirely sure is sane. However this works for my use case.
